### PR TITLE
Remove end of line character from regular expressions

### DIFF
--- a/pipes/replace.js
+++ b/pipes/replace.js
@@ -12,22 +12,22 @@ module.exports = (plugins, sake) => {
   // replace minimum WP version
   pipes.minimum_wp_version = lazypipe()
     .pipe(plugins.replace, /('minimum_wp_version'[\s]*=>[\s]*)'([^']*)'/, (match, m) => `${m}'${sake.options.minimum_wp_version}'`)
-    .pipe(plugins.replace, /Requires at least: .*\n/, () => `Requires at least: ${sake.options.minimum_wp_version}\n`)
+    .pipe(plugins.replace, /Requires at least: .*/, () => `Requires at least: ${sake.options.minimum_wp_version}`)
     .pipe(plugins.replace, /MINIMUM_WP_VERSION = .*\n/, () => `MINIMUM_WP_VERSION = '${sake.options.minimum_wp_version}';\n`)
 
   // replace tested up to WP version
   pipes.tested_up_to_wp_version = lazypipe()
-    .pipe(plugins.replace, /Tested up to: .*\n/, () => `Tested up to: ${sake.options.tested_up_to_wp_version}\n`)
+    .pipe(plugins.replace, /Tested up to: .*/, () => `Tested up to: ${sake.options.tested_up_to_wp_version}`)
 
   // replace minimum WC version
   pipes.minimum_wc_version = lazypipe()
     .pipe(plugins.replace, /('minimum_wc_version'[\s]*=>[\s]*)'([^']*)'/, (match, m) => `${m}'${sake.options.minimum_wc_version}'`)
-    .pipe(plugins.replace, /WC requires at least: .*\n/, () => `WC requires at least: ${sake.options.minimum_wc_version}\n`)
+    .pipe(plugins.replace, /WC requires at least: .*/, () => `WC requires at least: ${sake.options.minimum_wc_version}`)
     .pipe(plugins.replace, /MINIMUM_WC_VERSION = .*\n/, () => `MINIMUM_WC_VERSION = '${sake.options.minimum_wc_version}';\n`)
 
   // replace tested up to WC version
   pipes.tested_up_to_wc_version = lazypipe()
-    .pipe(plugins.replace, /WC tested up to: .*\n/, () => `WC tested up to: ${sake.options.tested_up_to_wc_version}\n`)
+    .pipe(plugins.replace, /WC tested up to: .*/, () => `WC tested up to: ${sake.options.tested_up_to_wc_version}`)
 
   // replace FW version
   pipes.framework_version = lazypipe()


### PR DESCRIPTION
# Summary

This PR updates the regular expressions used to update the Tested up to and minimum required versions in plugin headers.

### Story: [CH 65812](https://app.clubhouse.io/skyverge/story/65812)

## QA

Confirm that sake works for Facebook for WooCommerce and one of our plugins.

### Steps

#### Facebook for WooCommerce

1. Update `package.json` to use version `github:skyverge/sake#ch65812/remove-end-of-line-characters-from-some-regex` of saké
1. Run `npm install sake`
1. Run `npx sake fetch_latest_wp_wc_versions bump:minreqs --minimum_wp_version=4.5.0 --tested_up_to_wp_version=5.3.0 --tested_up_to_wc_version=4.0.0 --minimum_wc_version=4.0.0 --series`
1. Confirm that sake successfully set:
    - [x] The Minimum WP version header to `4.5.0`
    - [x] The Minimum WC version header to `4.0.0`
    - [x] The Tested up to header to `5.3.0`
    - [x] The WC tested up to header to `4.0.0`

#### Authorize.Net

1. Update `package.json` to use version `github:skyverge/sake#ch65812/remove-end-of-line-characters-from-some-regex` of saké
1. Run `npm install sake`
1. Run `npx sake fetch_latest_wp_wc_versions bump:minreqs --minimum_wp_version=4.5.0 --tested_up_to_wp_version=5.3.0 --tested_up_to_wc_version=4.0.0 --minimum_wc_version=4.0.0 --series`
1. Confirm that sake successfully set:
    - [x] The Minimum WP version header to `4.5.0`
    - [x] The Minimum WC version header to `4.0.0`
    - [x] The Tested up to header to `5.3.0`
    - [x] The WC tested up to header to `4.0.0`
