### PR TITLE
Exclude CODEOWNERS files from builds

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -53,7 +53,11 @@ module.exports = (gulp, plugins, sake) => {
       // skip tartufo files
       `!${sake.config.paths.src}/**/tool.tartufo`,
       `!${sake.config.paths.src}/**/exclude-patterns.txt`,
-      
+
+      // skip codeowners files
+      `!${sake.config.paths.src}/**/CODEOWNERS`,
+      `!${sake.config.paths.src}/**/codeowners`,
+
       // skip whitesource files
       `!${sake.config.paths.src}/**/.whitesource`,
 


### PR DESCRIPTION
## Summary

This PR adds the `CODEOWNERS` file to the list of files to exclude from builds.

#### Story: [MWC-244](https://jira.godaddy.com/browse/MWC-244)

## QA

1. Open a project that uses `CODEOWNERS`, for example, [Poynt](https://github.com/gdcorp-partners/poynt-for-woocommerce/).
1. [Switch to a development version of Sake](https://github.com/skyverge/sake/wiki/Using-a-development-version-of-Sak%C3%A9) using this branch
1. Try running `sake build`
    - [x] The build does not contain `CODEOWNERS`
1. Try running `sake zip`
    - [x] The build does not contain `CODEOWNERS`
