### PR TITLE
Update search:wt_update_key

### DIFF
--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -120,7 +120,7 @@ module.exports = (gulp, plugins, sake) => {
       if (err) sake.throwError(err)
 
       // matches " * Woo: ProductId:ProductKey" in the main plugin file PHPDoc
-      let phpDocMatch = data.match(/\s*\*\s*Woo:\s*\d*:(.+);/ig)
+      let phpDocMatch = data.match(/\s*\*\s*Woo:\s*\d*:(.+)/ig)
       // matches legacy woothemes_queue_update() usage in the main plugin file
       let phpFuncMatch = data.match(/woothemes_queue_update\s*\(\s*plugin_basename\s*\(\s*__FILE__\s*\)\s*,\s*'(.+)'\s*,\s*'(\d+)'\s*\);/ig)
 

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -119,7 +119,7 @@ module.exports = (gulp, plugins, sake) => {
     fs.readFile(`${sake.config.paths.src}/${sake.config.plugin.mainFile}`, 'utf8', (err, data) => {
       if (err) sake.throwError(err)
 
-      // matches "* Woo: ProductId::ProductKey" in the main plugin file PHPDoc
+      // matches "* Woo: ProductId:ProductKey" in the main plugin file PHPDoc
       let phpDocMatch = data.match(/\s*\*\s*Woo:\s*\d*:(.+);/ig)
       // matches legacy woothemes_queue_update() usage in the main plugin file
       let phpFuncMatch = data.match(/woothemes_queue_update\s*\(\s*plugin_basename\s*\(\s*__FILE__\s*\)\s*,\s*'(.+)'\s*,\s*'(\d+)'\s*\);/ig)

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -119,7 +119,7 @@ module.exports = (gulp, plugins, sake) => {
     fs.readFile(`${sake.config.paths.src}/${sake.config.plugin.mainFile}`, 'utf8', (err, data) => {
       if (err) sake.throwError(err)
 
-      // matches "* Woo: ProductId:ProductKey" in the main plugin file PHPDoc
+      // matches " * Woo: ProductId:ProductKey" in the main plugin file PHPDoc
       let phpDocMatch = data.match(/\s*\*\s*Woo:\s*\d*:(.+);/ig)
       // matches legacy woothemes_queue_update() usage in the main plugin file
       let phpFuncMatch = data.match(/woothemes_queue_update\s*\(\s*plugin_basename\s*\(\s*__FILE__\s*\)\s*,\s*'(.+)'\s*,\s*'(\d+)'\s*\);/ig)

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -120,9 +120,11 @@ module.exports = (gulp, plugins, sake) => {
       if (err) sake.throwError(err)
 
       // matches "* Woo: ProductId::ProductKey" in the main plugin file PHPDoc
-      let phpDocMatch = data.match(/\s*\*\s*Woo:\s*\d*:+(.+)+\n;/ig)
+      let phpDocMatch = data.match(/\s*\*\s*Woo:\s*\d*:(.+);/ig)
       // matches legacy woothemes_queue_update() usage in the main plugin file
       let phpFuncMatch = data.match(/woothemes_queue_update\s*\(\s*plugin_basename\s*\(\s*__FILE__\s*\)\s*,\s*'(.+)'\s*,\s*'(\d+)'\s*\);/ig)
+
+      log.info(phpDocMatch)
 
       // throw an error if no WT keys have been found with either method
       if (!phpDocMatch && !phpFuncMatch) {

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -119,9 +119,13 @@ module.exports = (gulp, plugins, sake) => {
     fs.readFile(`${sake.config.paths.src}/${sake.config.plugin.mainFile}`, 'utf8', (err, data) => {
       if (err) sake.throwError(err)
 
-      let results = data.match(/woothemes_queue_update\s*\(\s*plugin_basename\s*\(\s*__FILE__\s*\)\s*,\s*'(.+)'\s*,\s*'(\d+)'\s*\);/ig)
+      // matches "* Woo: ProductId::ProductKey" in the main plugin file PHPDoc
+      let phpDocMatch = data.match(/\s*\*\s*Woo:\s*\d*:+(.+)+\n;/ig)
+      // matches legacy woothemes_queue_update() usage in the main plugin file
+      let phpFuncMatch = data.match(/woothemes_queue_update\s*\(\s*plugin_basename\s*\(\s*__FILE__\s*\)\s*,\s*'(.+)'\s*,\s*'(\d+)'\s*\);/ig)
 
-      if (!results) {
+      // throw an error if no WT keys have been found with either method
+      if (!phpDocMatch && !phpFuncMatch) {
         sake.throwError('WooThemes updater keys for the plugin have not been properly set ;(')
       }
 

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -124,8 +124,6 @@ module.exports = (gulp, plugins, sake) => {
       // matches legacy woothemes_queue_update() usage in the main plugin file
       let phpFuncMatch = data.match(/woothemes_queue_update\s*\(\s*plugin_basename\s*\(\s*__FILE__\s*\)\s*,\s*'(.+)'\s*,\s*'(\d+)'\s*\);/ig)
 
-      log.info(phpDocMatch)
-
       // throw an error if no WT keys have been found with either method
       if (!phpDocMatch && !phpFuncMatch) {
         sake.throwError('WooThemes updater keys for the plugin have not been properly set ;(')


### PR DESCRIPTION
## Summary

Updates the `search:wt_update_key` to not produce errors if a plugin does no longer use the `woothemes_queue_update` but has a valid `Woo` header with product Id and key for the Woo updater.

### Story: [MWC 1644](https://jira.godaddy.com/browse/MWC-1644)

## QA

> Unfortunately the regex doesn't seem to work for me... But it's a bit strange, because I tested it into https://regex101.com/ and produces the expected results there...

### Setup

Follow [these steps](https://github.com/skyverge/sake/wiki/Using-a-development-version-of-Sak%C3%A9) to run a local copy of Sake using this branch.

Test this locally and try to launch the `sake search:wt_update_key` on 
* A) a plugin that either employ the `woothemes_queue_update` function 
* B) a plugin that no longer use this function and only have `* Woo: prodId:prodKey` data in the main plugin file phpdoc header

The tests should include the following outcomes (note that all plugins use currently _both_ these methods so to test things out you may need to remove one or the other conditionally):

### Steps

#### `woothemes_queue_update` plugin and no header

- [x] When the plugin has this function with a valid prod Id, prod key as the function args, the task passes
- [x] When the plugin does not have this function in the main plugin file, the task errors out
- [x] When the plugin does have this function in the main plugin file, but contains invalid data that does not match regex, the task errors out

#### `* Woo` header plugin and no php function

- [x] When the plugin has the Woo header with a valid prod Id, prod key, the task passes
- [x] When the plugin does not have this header in the main plugin file, the task errors out
- [x] When the plugin does have this function in the main plugin file, but contains invalid data that does not match regex, the task errors out

## Open questions

Are we ok with this the type of regex proposed? 
